### PR TITLE
Fixing a type error

### DIFF
--- a/torchfsm/operator/_base.py
+++ b/torchfsm/operator/_base.py
@@ -961,7 +961,7 @@ class _ExplicitSourceCore(NonlinearFunc):
         self,
         u_fft: FourierTensor["B C H ..."],
         f_mesh: FourierMesh,
-        u: SpatialTensor["B C H ..."] | None,
+        u: Optional[SpatialTensor["B C H ..."], None],
     ) -> FourierTensor["B C H ..."]:
         if self.source.device != f_mesh.device:
             self.source = self.source.to(f_mesh.device)


### PR DESCRIPTION
The error is coming from conda build [https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1242758&view=logs&jobId=4cabe686-70ae-553a-7fd0-310379f2cbac]:

```sh
    u: SpatialTensor["B C H ..."] | None,
TypeError: unsupported operand type(s) for |: '_AnnotatedAlias' and 'NoneType'
```