### PR TITLE
Fix Trajectory Recorder appending to trajectory from previous run

### DIFF
--- a/torchfsm/traj_recorder.py
+++ b/torchfsm/traj_recorder.py
@@ -148,7 +148,8 @@ class AutoRecorder(_TrajRecorder):
         if len(self._trajectory) == 0:
             return None
         if self.return_in_fourier:
-            return torch.stack(self._trajectory, dim=1)
+            self._trajectory = torch.stack(self._trajectory, dim=1)
+            return self._trajectory
         else:
             return self._traj_ifft(torch.stack(self._trajectory, dim=1)).real
 

--- a/torchfsm/traj_recorder.py
+++ b/torchfsm/traj_recorder.py
@@ -147,11 +147,11 @@ class AutoRecorder(_TrajRecorder):
     def trajectory(self):
         if len(self._trajectory) == 0:
             return None
+        self._trajectory = torch.stack(self._trajectory, dim=1)
         if self.return_in_fourier:
-            self._trajectory = torch.stack(self._trajectory, dim=1)
             return self._trajectory
         else:
-            return self._traj_ifft(torch.stack(self._trajectory, dim=1)).real
+            return self._traj_ifft(self._trajectory).real
 
 
 class CPURecorder(AutoRecorder):


### PR DESCRIPTION
Hi Qiang,

I encountered an issue when "re-using" an `AutoRecorder` for two consecutive integrations. In the example below

```python
from torchfsm.operator import Operator, Convection, Laplacian
from torchfsm.mesh import MeshGrid
from torchfsm.plot import plot_traj
from torchfsm.traj_recorder import AutoRecorder
import torch

def Burgers(nu:float) -> Operator:
    return nu*Laplacian()-Convection()
burgers=Burgers(0.01)

device='cuda' if torch.cuda.is_available() else 'cpu'
L=1.0; N=128; 
mesh=MeshGrid([(0,L,N)],device=device)
x=mesh.bc_mesh_grid()
u_0=torch.sin(2*torch.pi*x/L)+0.5

recorder = AutoRecorder()

traj=burgers.integrate(u_0=u_0,mesh=mesh,
    dt=0.01,step=200,
    trajectory_recorder=recorder,
)
traj_2=burgers.integrate(u_0=u_0,mesh=mesh,
    dt=0.01,step=200,
    trajectory_recorder=recorder,
)
plot_traj(traj_2,animation=False,cmap="managua")
```

`traj_2` is *not* independent from `traj` leading to the trajectories being concatenated, see below

<img width="1139" height="365" alt="image" src="https://github.com/user-attachments/assets/9ba5b230-b99f-4ee8-b573-9dab336829e3" />

There is already [a catch](https://github.com/qiauil/torchfsm/blob/b038ebcc7068d4e0f81ddb3306227a2bfca6b929/torchfsm/traj_recorder.py#L141-L144) you implemented if the trajectory has been stacked into a tensor such that the recorder throws an error. However, this code path is never taken because stacking does not update the internal class attribute.

This fix ensures the internal representation is updated. If you think it's a good addition, I guess we also have to update the other recorders to do the same.